### PR TITLE
fix: Distribute title of Markdown Container with locale

### DIFF
--- a/docs/.vitepress/config/style.ts
+++ b/docs/.vitepress/config/style.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitepress'
 import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons'
 import { MermaidMarkdown, MermaidPlugin } from "vitepress-plugin-mermaid"
+import { localeContainersPlugin } from "../plugin/locale-containers"
 
 export const style = defineConfig({
 
@@ -10,6 +11,7 @@ export const style = defineConfig({
     config(md) {
       md.use(groupIconMdPlugin)
       md.use(MermaidMarkdown)
+      localeContainersPlugin(md)
     }
 
   },

--- a/docs/.vitepress/config/zh.ts
+++ b/docs/.vitepress/config/zh.ts
@@ -52,17 +52,6 @@ export const zh = defineConfig({
             next: "下一页",
         }
     },
-    markdown: {
-      container: {
-        tipLabel: "提示",
-        warningLabel: "警告",
-        dangerLabel: "危险",
-        infoLabel: "信息",
-        detailsLabel: "详细信息"
-      },
-
-      codeCopyButtonTitle: "复制代码"
-    }
 });
 
 function mixinSidebar(): DefaultTheme.SidebarItem[] {

--- a/docs/.vitepress/plugin/locale-containers.ts
+++ b/docs/.vitepress/plugin/locale-containers.ts
@@ -1,0 +1,59 @@
+import type MarkdownIt from "markdown-it"
+
+const localeTitles: Record<string, Record<string, string>> = {
+  zh: {
+    tip: "提示",
+    warning: "警告",
+    danger: "危险",
+    info: "信息",
+    details: "详细信息",
+  },
+  en: {
+    tip: "TIP",
+    warning: "WARNING",
+    danger: "DANGER",
+    info: "INFO",
+    details: "Details",
+  },
+}
+
+function getLocale(env: any): string {
+  // localeIndex is set by VitePress to the locale key ("en", "zh", etc.)
+  if (env.localeIndex) return env.localeIndex
+  // Fallback: derive from relativePath
+  const path: string = env.relativePath || env.path || ""
+  if (path.startsWith("zh/") || path.startsWith("/zh/") || path.includes("/zh/")) return "zh"
+  return "en"
+}
+
+export function localeContainersPlugin(md: MarkdownIt): void {
+  const containerTypes = ["tip", "warning", "danger", "info", "details"] as const
+
+  for (const type of containerTypes) {
+    const ruleName = `container_${type}_open`
+    const defaultRender = md.renderer.rules[ruleName]
+    if (!defaultRender) continue
+
+    md.renderer.rules[ruleName] = (tokens, idx, options, env, self) => {
+      const token = tokens[idx]
+
+      if (token.nesting === 1) {
+        // info after stripping the container keyword ("tip", "warning", etc.)
+        const info = token.info.trim().slice(type.length).trim()
+        const locale = getLocale(env)
+        const defaultTitle = localeTitles[locale]?.[type] ?? localeTitles.en[type]
+
+        if (!info) {
+          // No custom title — temporarily swap in the locale-aware default.
+          const saved = token.info
+          token.info = `${type} ${defaultTitle}`
+          const result = defaultRender(tokens, idx, options, env, self)
+          token.info = saved
+          return result
+        }
+      }
+
+      return defaultRender(tokens, idx, options, env, self)
+    }
+  }
+}

--- a/docs/.vitepress/plugin/locale-containers.ts
+++ b/docs/.vitepress/plugin/locale-containers.ts
@@ -7,6 +7,7 @@ const localeTitles: Record<string, Record<string, string>> = {
     danger: "危险",
     info: "信息",
     details: "详细信息",
+    codeCopy: "复制代码",
   },
   en: {
     tip: "TIP",
@@ -14,6 +15,7 @@ const localeTitles: Record<string, Record<string, string>> = {
     danger: "DANGER",
     info: "INFO",
     details: "Details",
+    codeCopy: "Copy Code",
   },
 }
 
@@ -55,5 +57,27 @@ export function localeContainersPlugin(md: MarkdownIt): void {
 
       return defaultRender(tokens, idx, options, env, self)
     }
+  }
+
+  // Override fence renderer to inject locale-aware code copy button title.
+  // The preWrapperPlugin stores its options object on the original fence rule
+  // so we intercept the call and patch options.codeCopyButtonTitle per-page.
+  const originalFence = md.renderer.rules.fence
+  if (!originalFence) return
+
+  md.renderer.rules.fence = (...args: any[]) => {
+    const env = args[3]
+    const locale = getLocale(env)
+    const title = localeTitles[locale]?.codeCopy ?? localeTitles.en.codeCopy
+
+    // Inject locale-specific title into the HTML output.
+    const result = originalFence(...args)
+    if (typeof result === "string") {
+      return result.replace(
+        /title="[^"]*" class="copy"/,
+        `title="${title}" class="copy"`
+      )
+    }
+    return result
   }
 }


### PR DESCRIPTION
This PR fixes the problem for markdown container title like `TIP`, `WARNING`, `ERROR`, e.t.c. Vitepress not support to change its name with locale as default, so we configure it in `zh_ts` configurations is incorrect.

We use a hacky method to head off the original markdown container renderer and change it with locale, also has function for copy code button tips.